### PR TITLE
Added support for the IncludeScopes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ By default, the file will be written in plain text. The fields in the log file a
 | ----- | ----------- | ------ | ------- |
 | **Timestamp** | The time the event occurred. | ISO-8601 with offset | `2016-10-18T11:14:11.0881912+10:00`  |
 | **Request id** | Uniquely identifies all messages raised during a single web request. | Alphanumeric | `0HKVMUG8EMJO9` |
+| **Scopes** | Uniquely identifies all messages raised during a single web request. | Alphanumeric | `"Action" => "Options"` |
 | **Level** | The log level assigned to the event. | Three-character code in brackets | `[INF]` |
 | **Message** | The log message associated with the event. | Free text | `Hello, world!` |
 | **Event id** | Identifies messages generated from the same format string/message template. | 32-bit hexadecimal, in parentheses | `(f83bcf75)` |
@@ -119,6 +120,7 @@ The `AddFile()` method exposes some basic options for controlling the connection
 | `minimumLevel` | The level below which events will be suppressed (the default is `LogLevel.Information`). | `LogLevel.Debug` |
 | `levelOverrides` | A dictionary mapping logger name prefixes to minimum logging levels. | |
 | `isJson` | If true, the log file will be written in JSON format. | `true` |
+| `includeScopes` | If true, the log entires will include their scopes. | `true` |
 | `fileSizeLimitBytes` | The maximum size, in bytes, to which any single log file will be allowed to grow. For unrestricted growth, pass`null`. The default is 1 GiB. | `1024 * 1024 * 1024` |
 | `retainedFileCountLimit` | The maximum number of log files that will be retained, including the current log file. For unlimited retention, pass `null`. The default is `31`. | `31` |
 
@@ -132,6 +134,7 @@ In `appsettings.json` add a `"Logging"` property:
 {
   "Logging": {
     "PathFormat": "Logs/log-{Date}.txt",
+    "IncludeScopes": false,
     "LogLevel": {
       "Default": "Debug",
       "Microsoft": "Information"
@@ -151,6 +154,7 @@ In addition to the properties shown above, the `"Logging"` configuration support
 | Property | Description | Example |
 | -------- | ----------- | ------- |
 | `Json` | If `true`, the log file will be written in JSON format. | `true` |
+| `IncludeScopes` | If true, the log entires will include their scopes. | `true` |
 | `FileSizeLimitBytes` | The maximum size, in bytes, to which any single log file will be allowed to grow. For unrestricted growth, pass`null`. The default is 1 GiB. | `1024 * 1024 * 1024` |
 | `RetainedFileCountLimit` | The maximum number of log files that will be retained, including the current log file. For unlimited retention, pass `null`. The default is `31`. | `31` |
 

--- a/example/WebApplication/Controllers/HomeController.cs
+++ b/example/WebApplication/Controllers/HomeController.cs
@@ -27,8 +27,13 @@ namespace WebApplication.Controllers
 
         public IActionResult About()
         {
-            ViewData["Message"] = "Your application description page.";
 
+            using (_log.BeginScope("HomeController:About"))
+            {
+                _log.LogInformation("About");
+
+                ViewData["Message"] = "Your application description page.";
+            }
             return View();
         }
 

--- a/src/Serilog.Extensions.Logging.File/Serilog/Extensions/Logging/File/FileLoggingConfiguration.cs
+++ b/src/Serilog.Extensions.Logging.File/Serilog/Extensions/Logging/File/FileLoggingConfiguration.cs
@@ -23,6 +23,12 @@
         { get; set; }
 
         /// <summary>
+        /// If <c>true</c>, the logs entries will include their scopes.
+        /// </summary>
+        public bool IncludeScopes
+        { get; set; }
+
+        /// <summary>
         /// The maximum size, in bytes, to which any single log file will be
         /// allowed to grow. For unrestricted growth, pass <c>null</c>. The
         /// default is 1 GiB.

--- a/src/Serilog.Extensions.Logging.File/Serilog/Extensions/Logging/File/ScopeEnrricher.cs
+++ b/src/Serilog.Extensions.Logging.File/Serilog/Extensions/Logging/File/ScopeEnrricher.cs
@@ -1,0 +1,24 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+using System.Linq;
+
+namespace Serilog.Extensions.Logging.File
+{
+    class ScopeEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (!logEvent.Properties.ContainsKey("Scope"))
+                return;
+
+            var scopes = logEvent.Properties["Scope"] as SequenceValue;
+
+            if (scopes == null)
+                return;
+
+            string scopeValues = string.Join(" => ", scopes.Elements.Select(x => x.ToString()));
+
+            logEvent.AddOrUpdateProperty(new LogEventProperty("Scopes", new ScalarValue(scopeValues)));
+        }
+    }
+}


### PR DESCRIPTION
Added support for the IncludeScopes option from Microsoft.Extensions.Logging

This option allows the user to log the scopes created by the ILogger.BeginScope() function
```
using (_log.BeginScope("HomeController:About"))
{

}
```

in the format 
2017-09-04T12:23:41.7735962+02:00 0HL7JFS1C6IAQ:00000001 **"Scope1" => "Scope2" => "Scope3"** [INF] Request finished in 1854.3777ms 200 text/html; charset=utf-8 (791a596a)

Similar to Microsoft.Extensions.Logging.Console