### PR TITLE
Move from RollingFile to File package

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The `AddFile()` method exposes some basic options for controlling the connection
 
 | Parameter | Description | Example value |
 | --------- | ----------- | ------------- |
-| `pathFormat` | Filename to write. The filename may include `{Date}` to specify how the date portion of the filename is calculated. May include environment variables.| `Logs/log-.txt` |
+| `pathFormat` | Filename to write. May include environment variables.| `Logs/log-.txt` |
 | `minimumLevel` | The level below which events will be suppressed (the default is `LogLevel.Information`). | `LogLevel.Debug` |
 | `levelOverrides` | A dictionary mapping logger name prefixes to minimum logging levels. | |
 | `isJson` | If true, the log file will be written in JSON format. | `true` |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This package makes it a one-liner - `loggerFactory.AddFile()` - to configure top-quality file logging for ASP.NET Core apps.
 
  * Text or JSON file output
- * Files roll over on date; capped file size
+ * Files roll over on day; capped file size
  * Request ids and event ids included with each message
  * Writes are performed on a background thread
  * Files are periodically flushed to disk (required for Azure App Service log collection)
@@ -25,7 +25,7 @@ You can get started quickly with this package, and later migrate to the full Ser
 WebHost.CreateDefaultBuilder(args)
     .ConfigureLogging((hostingContext, builder) =>
     {
-        builder.AddFile("Logs/myapp-{Date}.txt");
+        builder.AddFile("Logs/myapp.txt");
     })
     .UseStartup<Startup>()
     .Build();
@@ -72,7 +72,7 @@ By default, the file will be written in plain text. The fields in the log file a
 To record events in newline-separated JSON instead, specify `isJson: true` when configuring the logger:
 
 ```csharp
-loggingBuilder.AddFile("Logs/myapp-{Date}.txt", isJson: true);
+loggingBuilder.AddFile("Logs/myapp.txt", isJson: true);
 ```
 
 This will produce a log file with lines like:
@@ -122,7 +122,7 @@ The `AddFile()` method exposes some basic options for controlling the connection
 | `fileSizeLimitBytes` | The maximum size, in bytes, to which any single log file will be allowed to grow. For unrestricted growth, pass`null`. The default is 1 GiB. | `1024 * 1024 * 1024` |
 | `retainedFileCountLimit` | The maximum number of log files that will be retained, including the current log file. For unlimited retention, pass `null`. The default is `31`. | `31` |
 | `outputTemplate` | The template used for formatting plain text log output. The default is `{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}){NewLine}{Exception}` | `{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} {Properties:j} ({EventId:x8}){NewLine}{Exception}` |
-| `RollingInterval` | The interval used for rolling the file. For unlimited logging to single file, pass `Infinite`. The default is `Day`. | `Day` |
+| `rollingInterval` | The interval used for rolling the file. For unlimited logging to single file, pass `RollingInterval.Infinite`. The default is `RollingInterval.Day`. | `RollingInterval.Day` |
 
 ### `appsettings.json` configuration
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ The JSON document includes all properties associated with the event, not just th
 
 ### Rolling
 
-The filename provided to `AddFile()` should include the `{Date}` placeholder, which will be replaced with the date of the events contained in the file. Filenames use the `yyyyMMdd` date format so that files can be ordered using a lexicographic sort:
+The rollingInterval provided to `AddFile()` allows you to configure the interval at which files are rolled, by default day rolling is set up. Filenames use the `yyyyMMdd` date format for day rolling so that files can be ordered using a lexicographic sort:
 
 ```
-log-20160631.txt
-log-20160701.txt
-log-20160702.txt
+log20160631.txt
+log20160701.txt
+log20160702.txt
 ```
 
 To prevent outages due to disk space exhaustion, each file is capped to 1 GB in size. If the file size is exceeded, events will be dropped until the next roll point.
@@ -132,7 +132,7 @@ In `appsettings.json` add a `"Logging"` property:
 ```json
 {
   "Logging": {
-    "PathFormat": "Logs/log-{Date}.txt",
+    "PathFormat": "Logs/log.txt",
     "LogLevel": {
       "Default": "Debug",
       "Microsoft": "Information"
@@ -155,6 +155,7 @@ In addition to the properties shown above, the `"Logging"` configuration support
 | `FileSizeLimitBytes` | The maximum size, in bytes, to which any single log file will be allowed to grow. For unrestricted growth, pass`null`. The default is 1 GiB. | `1024 * 1024 * 1024` |
 | `RetainedFileCountLimit` | The maximum number of log files that will be retained, including the current log file. For unlimited retention, pass `null`. The default is `31`. | `31` |
 | `OutputTemplate` | The template used for formatting plain text log output. The default is `{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}){NewLine}{Exception}` | `{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} {Properties:j} ({EventId:x8}){NewLine}{Exception}` |
+| `RollingInterval` | The interval used for rolling the file. For unlimited logging to single file, pass `Infinite`. The default is `Day`. | `Day`
 
 ### Using the full Serilog API
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ This package is opinionated, providing the most common/recommended options suppo
 The following packages are used to provide `AddFile()`:
 
  * [Serilog](https://github.com/serilog/serilog) - the core logging pipeline
- * [Serilog.Sinks.RollingFile](https://github.com/serilog/serilog-sinks-rollingfile) - rolling file output
+ * [Serilog.Sinks.File](https://github.com/serilog/serilog-sinks-file) - (rolling) file output
  * [Serilog.Formatting.Compact](https://github.com/serilog/serilog-formatting-compact) - JSON event formatting
  * [Serilog.Extensions.Logging](https://github.com/serilog/serilog-extensions-logging) - ASP.NET Core integration
  * [Serilog.Sinks.Async](https://github.com/serilog/serilog-sinks-async) - async wrapper to perform log writes on a background thread

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The `AddFile()` method exposes some basic options for controlling the connection
 | `fileSizeLimitBytes` | The maximum size, in bytes, to which any single log file will be allowed to grow. For unrestricted growth, pass`null`. The default is 1 GiB. | `1024 * 1024 * 1024` |
 | `retainedFileCountLimit` | The maximum number of log files that will be retained, including the current log file. For unlimited retention, pass `null`. The default is `31`. | `31` |
 | `outputTemplate` | The template used for formatting plain text log output. The default is `{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}){NewLine}{Exception}` | `{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} {Properties:j} ({EventId:x8}){NewLine}{Exception}` |
+| `RollingInterval` | The interval used for rolling the file. For unlimited logging to single file, pass `Infinite`. The default is `Day`. | `Day` |
 
 ### `appsettings.json` configuration
 
@@ -155,7 +156,7 @@ In addition to the properties shown above, the `"Logging"` configuration support
 | `FileSizeLimitBytes` | The maximum size, in bytes, to which any single log file will be allowed to grow. For unrestricted growth, pass`null`. The default is 1 GiB. | `1024 * 1024 * 1024` |
 | `RetainedFileCountLimit` | The maximum number of log files that will be retained, including the current log file. For unlimited retention, pass `null`. The default is `31`. | `31` |
 | `OutputTemplate` | The template used for formatting plain text log output. The default is `{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}){NewLine}{Exception}` | `{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} {Properties:j} ({EventId:x8}){NewLine}{Exception}` |
-| `RollingInterval` | The interval used for rolling the file. For unlimited logging to single file, pass `Infinite`. The default is `Day`. | `Day`
+| `RollingInterval` | The interval used for rolling the file. For unlimited logging to single file, pass `Infinite`. The default is `Day`. | `Day` |
 
 ### Using the full Serilog API
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can get started quickly with this package, and later migrate to the full Ser
 **1.** Add [the NuGet package](https://nuget.org/packages/serilog.extensions.logging.file) as a dependency of your project either with the package manager or directly to the CSPROJ file:
 
 ```xml
-<PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
+<PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
 ```
 
 **2.** In your `Program` class, configure logging on the web host builder, and call `AddFile()` on the provided `loggingBuilder`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can get started quickly with this package, and later migrate to the full Ser
 WebHost.CreateDefaultBuilder(args)
     .ConfigureLogging((hostingContext, builder) =>
     {
-        builder.AddFile("Logs/myapp.txt");
+        builder.AddFile("Logs/myapp-.txt");
     })
     .UseStartup<Startup>()
     .Build();
@@ -72,7 +72,7 @@ By default, the file will be written in plain text. The fields in the log file a
 To record events in newline-separated JSON instead, specify `isJson: true` when configuring the logger:
 
 ```csharp
-loggingBuilder.AddFile("Logs/myapp.txt", isJson: true);
+loggingBuilder.AddFile("Logs/myapp-.txt", isJson: true);
 ```
 
 This will produce a log file with lines like:
@@ -88,9 +88,9 @@ The JSON document includes all properties associated with the event, not just th
 The rollingInterval provided to `AddFile()` allows you to configure the interval at which files are rolled, by default day rolling is set up. Filenames use the `yyyyMMdd` date format for day rolling so that files can be ordered using a lexicographic sort:
 
 ```
-log20160631.txt
-log20160701.txt
-log20160702.txt
+log-20160631.txt
+log-20160701.txt
+log-20160702.txt
 ```
 
 To prevent outages due to disk space exhaustion, each file is capped to 1 GB in size. If the file size is exceeded, events will be dropped until the next roll point.
@@ -115,7 +115,7 @@ The `AddFile()` method exposes some basic options for controlling the connection
 
 | Parameter | Description | Example value |
 | --------- | ----------- | ------------- |
-| `pathFormat` | Filename to write. The filename may include `{Date}` to specify how the date portion of the filename is calculated. May include environment variables.| `Logs/log-{Date}.txt` |
+| `pathFormat` | Filename to write. The filename may include `{Date}` to specify how the date portion of the filename is calculated. May include environment variables.| `Logs/log-.txt` |
 | `minimumLevel` | The level below which events will be suppressed (the default is `LogLevel.Information`). | `LogLevel.Debug` |
 | `levelOverrides` | A dictionary mapping logger name prefixes to minimum logging levels. | |
 | `isJson` | If true, the log file will be written in JSON format. | `true` |
@@ -133,7 +133,7 @@ In `appsettings.json` add a `"Logging"` property:
 ```json
 {
   "Logging": {
-    "PathFormat": "Logs/log.txt",
+    "PathFormat": "Logs/log-.txt",
     "LogLevel": {
       "Default": "Debug",
       "Microsoft": "Information"

--- a/example/WebApplication/appsettings.json
+++ b/example/WebApplication/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "Logging": {
-    "PathFormat": "Logs/log.txt",
+    "PathFormat": "Logs/log-.txt",
     "OutputTemplate": "{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}) {Properties:j}{NewLine}{Exception}",
     "IncludeScopes": true,
     "RollingInterval": "Day",

--- a/example/WebApplication/appsettings.json
+++ b/example/WebApplication/appsettings.json
@@ -1,8 +1,9 @@
 ﻿{
   "Logging": {
-    "PathFormat": "Logs/log-{Date}.txt",
+    "PathFormat": "Logs/log.txt",
     "OutputTemplate": "{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}) {Properties:j}{NewLine}{Exception}",
     "IncludeScopes": true,
+    "RollingInterval": "Day",
     "LogLevel": {
       "Default": "Warning"
     }

--- a/src/Serilog.Extensions.Logging.File/Microsoft/Extensions/Logging/FileLoggerExtensions.cs
+++ b/src/Serilog.Extensions.Logging.File/Microsoft/Extensions/Logging/FileLoggerExtensions.cs
@@ -37,7 +37,14 @@ namespace Microsoft.Extensions.Logging
             var minimumLevel = GetMinimumLogLevel(configuration);
             var levelOverrides = GetLevelOverrides(configuration);
 
-            return loggerFactory.AddFile(config.PathFormat, minimumLevel, levelOverrides, config.Json, config.FileSizeLimitBytes, config.RetainedFileCountLimit, config.OutputTemplate);
+            return loggerFactory.AddFile(config.PathFormat,
+                                         minimumLevel,
+                                         levelOverrides,
+                                         config.Json,
+                                         config.FileSizeLimitBytes,
+                                         config.RetainedFileCountLimit,
+                                         config.OutputTemplate,
+                                         config.RollingInterval);
         }
 
         /// <summary>
@@ -55,6 +62,7 @@ namespace Microsoft.Extensions.Logging
         /// log file. For unlimited retention, pass null. The default is 31.</param>
         /// <param name="outputTemplate">The template used for formatting plain text log output. The default is
         /// "{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}){NewLine}{Exception}"</param>
+        /// <param name="rollingInterval">The interval used for rolling the file. The default is <see cref="RollingInterval.Day"/>.</param>
         /// <returns>A logger factory to allow further configuration.</returns>
         public static ILoggerFactory AddFile(
             this ILoggerFactory loggerFactory,
@@ -64,9 +72,18 @@ namespace Microsoft.Extensions.Logging
             bool isJson = false,
             long? fileSizeLimitBytes = FileLoggingConfiguration.DefaultFileSizeLimitBytes,
             int? retainedFileCountLimit = FileLoggingConfiguration.DefaultRetainedFileCountLimit,
-            string outputTemplate = FileLoggingConfiguration.DefaultOutputTemplate)
+            string outputTemplate = FileLoggingConfiguration.DefaultOutputTemplate,
+            RollingInterval rollingInterval = FileLoggingConfiguration.DefaultRollingInterval)
         {
-            var logger = CreateLogger(pathFormat, minimumLevel, levelOverrides, isJson, fileSizeLimitBytes, retainedFileCountLimit, outputTemplate);
+            var logger = CreateLogger(pathFormat,
+                                      minimumLevel,
+                                      levelOverrides,
+                                      isJson,
+                                      fileSizeLimitBytes,
+                                      retainedFileCountLimit,
+                                      outputTemplate,
+                                      rollingInterval);
+
             return loggerFactory.AddSerilog(logger, dispose: true);
         }
 
@@ -91,7 +108,14 @@ namespace Microsoft.Extensions.Logging
             var minimumLevel = GetMinimumLogLevel(configuration);
             var levelOverrides = GetLevelOverrides(configuration);
 
-            return loggingBuilder.AddFile(config.PathFormat, minimumLevel, levelOverrides, config.Json, config.FileSizeLimitBytes, config.RetainedFileCountLimit, config.OutputTemplate);
+            return loggingBuilder.AddFile(config.PathFormat,
+                                          minimumLevel,
+                                          levelOverrides,
+                                          config.Json,
+                                          config.FileSizeLimitBytes,
+                                          config.RetainedFileCountLimit,
+                                          config.OutputTemplate,
+                                          config.RollingInterval);
         }
 
         /// <summary>
@@ -109,6 +133,7 @@ namespace Microsoft.Extensions.Logging
         /// log file. For unlimited retention, pass null. The default is 31.</param>
         /// <param name="outputTemplate">The template used for formatting plain text log output. The default is
         /// "{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}){NewLine}{Exception}"</param>
+        /// <param name="rollingInterval">The interval used for rolling the file. The default is <see cref="RollingInterval.Day"/>.</param>
         /// <returns>The logging builder to allow further configuration.</returns>
         public static ILoggingBuilder AddFile(this ILoggingBuilder loggingBuilder,
             string pathFormat,
@@ -117,9 +142,17 @@ namespace Microsoft.Extensions.Logging
             bool isJson = false,
             long? fileSizeLimitBytes = FileLoggingConfiguration.DefaultFileSizeLimitBytes,
             int? retainedFileCountLimit = FileLoggingConfiguration.DefaultRetainedFileCountLimit,
-            string outputTemplate = FileLoggingConfiguration.DefaultOutputTemplate)
+            string outputTemplate = FileLoggingConfiguration.DefaultOutputTemplate,
+            RollingInterval rollingInterval = FileLoggingConfiguration.DefaultRollingInterval)
         {
-            var logger = CreateLogger(pathFormat, minimumLevel, levelOverrides, isJson, fileSizeLimitBytes, retainedFileCountLimit, outputTemplate);
+            var logger = CreateLogger(pathFormat,
+                                      minimumLevel,
+                                      levelOverrides,
+                                      isJson,
+                                      fileSizeLimitBytes,
+                                      retainedFileCountLimit,
+                                      outputTemplate,
+                                      rollingInterval);
 
             return loggingBuilder.AddSerilog(logger, dispose: true);
         }
@@ -130,7 +163,8 @@ namespace Microsoft.Extensions.Logging
             bool isJson,
             long? fileSizeLimitBytes,
             int? retainedFileCountLimit,
-            string outputTemplate)
+            string outputTemplate,
+            RollingInterval rollingInterval)
         {
             if (pathFormat == null) throw new ArgumentNullException(nameof(pathFormat));
 
@@ -149,7 +183,8 @@ namespace Microsoft.Extensions.Logging
                     fileSizeLimitBytes: fileSizeLimitBytes,
                     retainedFileCountLimit: retainedFileCountLimit,
                     shared: true,
-                    flushToDiskInterval: TimeSpan.FromSeconds(2)));
+                    flushToDiskInterval: TimeSpan.FromSeconds(2),
+                    rollingInterval: rollingInterval));
 
             if (!isJson)
             {

--- a/src/Serilog.Extensions.Logging.File/Microsoft/Extensions/Logging/FileLoggerExtensions.cs
+++ b/src/Serilog.Extensions.Logging.File/Microsoft/Extensions/Logging/FileLoggerExtensions.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Extensions.Logging
             var configuration = new LoggerConfiguration()
                 .MinimumLevel.Is(Conversions.MicrosoftToSerilogLevel(minimumLevel))
                 .Enrich.FromLogContext()
-                .WriteTo.Async(w => w.RollingFile(
+                .WriteTo.Async(w => w.File(
                     formatter,
                     Environment.ExpandEnvironmentVariables(pathFormat),
                     fileSizeLimitBytes: fileSizeLimitBytes,

--- a/src/Serilog.Extensions.Logging.File/Serilog.Extensions.Logging.File.csproj
+++ b/src/Serilog.Extensions.Logging.File/Serilog.Extensions.Logging.File.csproj
@@ -25,11 +25,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.1.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
   </ItemGroup>

--- a/src/Serilog.Extensions.Logging.File/Serilog.Extensions.Logging.File.csproj
+++ b/src/Serilog.Extensions.Logging.File/Serilog.Extensions.Logging.File.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />

--- a/src/Serilog.Extensions.Logging.File/Serilog/Extensions/Logging/File/FileLoggingConfiguration.cs
+++ b/src/Serilog.Extensions.Logging.File/Serilog/Extensions/Logging/File/FileLoggingConfiguration.cs
@@ -11,6 +11,8 @@
         internal const string DefaultOutputTemplate =
             "{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}){NewLine}{Exception}";
 
+        internal const RollingInterval DefaultRollingInterval = RollingInterval.Day;
+
         /// <summary>
         /// Filename to write. The filename may include <c>{Date}</c> to specify
         /// how the date portion of the filename is calculated. May include
@@ -46,5 +48,11 @@
         /// The default is "{Timestamp:o} {RequestId,13} [{Level:u3}] {Message} ({EventId:x8}){NewLine}{Exception}"
         /// </summary>
         public string OutputTemplate { get; set; } = DefaultOutputTemplate;
+
+        /// <summary>
+        /// The interval used for rolling the file.
+        /// The default is <see cref="RollingInterval.Day"/>.
+        /// </summary>
+        public RollingInterval RollingInterval { get; set; } = DefaultRollingInterval;
     }
 }


### PR DESCRIPTION
I've moved the package over from Serilog.Sinks.RollingFile to Serilog.Sinks.File like it's recommended for new projects. This does create a breaking change because the rolling behaviour is supposed to be configured differently. So I think this should be released as part of a new major version. (Also updated the Serilog packages)