### PR TITLE
Add 'UtcDateTime' as a first class citizen, via an enricher similar to JSON

### DIFF
--- a/src/Serilog.Extensions.Logging.File/Microsoft/Extensions/Logging/FileLoggerExtensions.cs
+++ b/src/Serilog.Extensions.Logging.File/Microsoft/Extensions/Logging/FileLoggerExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds a file logger initialized from the supplied configuration section.
         /// </summary>
         /// <param name="loggerFactory">The logger factory.</param>
-        /// <param name="pathFormat">Filname to write. The filename may include {Date} to specify how the date portion of the 
+        /// <param name="pathFormat">Filname to write. The filename may include {Date} to specify how the date portion of the
         /// filename is calculated. May include environment variables.</param>
         /// <param name="minimumLevel">The level below which events will be suppressed (the default is <see cref="LogLevel.Information"/>).</param>
         /// <param name="levelOverrides">A dictionary mapping logger name prefixes to minimum logging levels.</param>
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds a file logger initialized from the supplied configuration section.
         /// </summary>
         /// <param name="loggingBuilder">The logging builder.</param>
-        /// <param name="pathFormat">Filname to write. The filename may include {Date} to specify how the date portion of the 
+        /// <param name="pathFormat">Filname to write. The filename may include {Date} to specify how the date portion of the
         /// filename is calculated. May include environment variables.</param>
         /// <param name="minimumLevel">The level below which events will be suppressed (the default is <see cref="LogLevel.Information"/>).</param>
         /// <param name="levelOverrides">A dictionary mapping logger name prefixes to minimum logging levels.</param>
@@ -154,6 +154,11 @@ namespace Microsoft.Extensions.Logging
             if (!isJson)
             {
                 configuration.Enrich.With<EventIdEnricher>();
+            }
+
+            if (outputTemplate.Contains("UtcDateTime"))
+            {
+                configuration.Enrich.With<UtcEnricher>();
             }
 
             foreach (var levelOverride in levelOverrides ?? new Dictionary<string, LogLevel>())

--- a/src/Serilog.Extensions.Logging.File/Serilog/Extensions/Logging/File/UtcEnricher.cs
+++ b/src/Serilog.Extensions.Logging.File/Serilog/Extensions/Logging/File/UtcEnricher.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting.Compact;
+
+namespace Serilog.Extensions.Logging.File
+{
+    class UtcEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            logEvent.AddOrUpdateProperty(new LogEventProperty("UtcDateTime", new ScalarValue(DateTime.UtcNow)));
+        }
+    }
+}


### PR DESCRIPTION
Promotes `UtcDateNow` (based on UTC time) to a first class citizen equal to local time (`Timestamp`). Formatting specifiers (`:o`, `:F`, etc.) work as expected.

This elevates _serilog-extensions-logging-file_ to mirror the functionality available elsewhere in .NET, which treats `.Now` and `.UtcNow` equally without preference, and the functionality elsewhere in _Microsoft.Extensions.Logging.ILogger_ that enables using UTC with a simple bool flag.